### PR TITLE
feat: text edit undo/redo, keyboard shortcuts, paragraph grouping, cu…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1462,6 +1462,7 @@
             <label class="bates-label">Mode</label>
             <select id="optimize-mode" class="bates-field">
               <option value="smart" selected>Smart — preserve text, compress images</option>
+              <option value="images">Images Only — recompress embedded images</option>
               <option value="aggressive">Aggressive — rasterize all pages</option>
             </select>
           </div>
@@ -1831,6 +1832,14 @@
             <div class="shortcut-row"><span>Zoom out</span><kbd>−</kbd></div>
             <div class="shortcut-row"><span>Previous page</span><kbd>Ctrl+[</kbd></div>
             <div class="shortcut-row"><span>Next page</span><kbd>Ctrl+]</kbd></div>
+          </div>
+          <div class="shortcuts-section">
+            <h3 class="shortcuts-section-title">Text Editing</h3>
+            <div class="shortcut-row"><span>Bold</span><kbd>Ctrl+B</kbd></div>
+            <div class="shortcut-row"><span>Italic</span><kbd>Ctrl+I</kbd></div>
+            <div class="shortcut-row"><span>Undo edit</span><kbd>Ctrl+Z</kbd></div>
+            <div class="shortcut-row"><span>Redo edit</span><kbd>Ctrl+Y</kbd></div>
+            <div class="shortcut-row"><span>Apply changes</span><kbd>Ctrl+Enter</kbd></div>
           </div>
           <div class="shortcuts-section">
             <h3 class="shortcuts-section-title">General</h3>

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -1042,6 +1042,24 @@ html, body {
   background: rgba(255, 255, 255, 0.95);
 }
 
+/* Paragraph grouping indicator — vertical bar to show grouped lines */
+.text-edit-paragraph {
+  background: var(--mb-accent);
+  border-radius: 2px;
+  opacity: 0.3;
+  z-index: 14;
+  transition: opacity 0.2s;
+}
+.text-edit-paragraph:hover {
+  opacity: 0.6;
+}
+
+/* Undo/redo button disabled state */
+.text-edit-btn:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
 /* ── Text/Image Edit Toolbar ── */
 
 .text-edit-toolbar {
@@ -2109,6 +2127,9 @@ html[data-theme="dark"] .text-edit-line:focus {
 }
 html[data-theme="dark"] .text-edit-line.text-edit-dirty {
   background: rgba(234, 179, 8, 0.08);
+}
+html[data-theme="dark"] .text-edit-paragraph {
+  background: var(--mb-accent);
 }
 
 html[data-theme="dark"] .image-edit-btn {

--- a/sw.js
+++ b/sw.js
@@ -4,7 +4,7 @@
  * cache-first for local assets.
  */
 
-const CACHE_VERSION = 'mudbrick-v3.1';
+const CACHE_VERSION = 'mudbrick-v3.2';
 
 /* App shell — local assets */
 const SHELL_ASSETS = [


### PR DESCRIPTION
…stom fonts, per-image optimization

Text editing improvements:
- Ctrl+B/I keyboard shortcuts synced with toolbar state
- Ctrl+Z/Y undo/redo with per-line snapshots (50-level stack)
- Ctrl+Enter to apply, Escape to cancel
- Paragraph grouping with visual indicator bar for adjacent lines
- Custom font upload (TTF/OTF) via toolbar with CSS @font-face + pdf-lib embedding

PDF optimization:
- New "Images Only" mode that recompresses individual embedded images without rasterizing pages — preserves all text, vectors, fonts, links
- Walks PDF indirect objects to find image XObjects, decodes via canvas, recompresses as JPEG, replaces only if smaller

UI updates:
- Undo/redo buttons in text edit toolbar with disabled state styling
- "Upload font..." option in font family selector
- "Images Only" mode option in optimize modal with contextual hint
- Text Editing section added to keyboard shortcuts modal
- Service worker cache bumped to v3.2

https://claude.ai/code/session_01FYSoQFLmnAH1s2vABgVCQF