### PR TITLE
feat: color-match for text editing — auto-detect and eyedropper

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -810,7 +810,7 @@ function handleEditText() {
     DOM.btnEditText.classList.remove('active');
     return;
   }
-  enterTextEditMode(State.currentPage, State.pdfDoc, State._viewport, DOM.textLayer)
+  enterTextEditMode(State.currentPage, State.pdfDoc, State._viewport, DOM.textLayer, DOM.pdfCanvas)
     .then(ok => {
       if (ok) DOM.btnEditText.classList.add('active');
     }).catch(err => console.warn('Text edit failed:', err));


### PR DESCRIPTION
- Sample text color from rendered PDF canvas using getImageData pixel analysis
- Auto-populate text overlays with matched color on entering text-edit mode
- Color picker defaults to matched color instead of black when focusing a line
- Committed text preserves original color (matched color used as fallback)
- Add eyedropper button to text-edit toolbar (uses native EyeDropper API on Chrome 95+, falls back to canvas click-to-pick on other browsers)
- Pass pdfCanvas reference from app.js to enterTextEditMode

https://claude.ai/code/session_01FYSoQFLmnAH1s2vABgVCQF