### PR TITLE
Fix icon rail disappearing after page navigation

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -818,9 +818,14 @@ function goToPage(pageNum) {
   updatePageNav();
   highlightActiveThumbnail();
 
-  // Scroll thumbnail into view
+  // Scroll thumbnail into view (within thumbnail list only — prevent app-level scroll)
   const thumb = DOM.thumbnailList.querySelector(`[data-page="${clamped}"]`);
-  if (thumb) thumb.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  if (thumb) {
+    thumb.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    // Prevent scrollIntoView from scrolling the #app grid container
+    DOM.app.scrollLeft = 0;
+    DOM.app.scrollTop = 0;
+  }
 
   // Scroll canvas area to top on page change
   DOM.canvasArea.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
## Summary

- **Fixed icon rail/titlebar shifting off-screen**: `thumbnail.scrollIntoView()` was bubbling up to the `#app` grid container, setting `scrollLeft` to a non-zero value. This pushed the icon rail (48px column 1) and part of the titlebar off the left edge of the viewport. Especially visible after navigating pages when the flyout panel was closed.

## Test plan

- [ ] Open a PDF, navigate between pages using thumbnails or Next/Prev buttons
- [ ] Verify the icon rail stays visible on the left at all times
- [ ] Close the flyout panel (View → Toggle Sidebar), navigate pages, verify icon rail stays put
- [ ] Toggle dark/light mode after navigation — verify full layout visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)