### PR TITLE
Fix Toggle Sidebar menu item (was no-op)

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3158,8 +3158,10 @@ function toggleDarkMode() {
 /* ═══════════════════ Sidebar Toggle ═══════════════════ */
 
 function toggleSidebar() {
-  // Legacy — sidebar replaced by icon rail + flyout panels
-  // Kept as no-op for any remaining references
+  // Toggle the flyout panel (replaces legacy sidebar)
+  if (typeof UIController !== 'undefined' && UIController.toggleFlyout) {
+    UIController.toggleFlyout('pages');
+  }
 }
 
 /* ═══════════════════ Properties Panel ═══════════════════ */


### PR DESCRIPTION
## Summary

- **Fixed View → Toggle Sidebar**: Was a no-op function after the UI refactor. Now toggles the Pages flyout panel via `UIController.toggleFlyout('pages')`.

## Test plan

- [ ] Open a PDF, click View → Toggle Sidebar — verify flyout panel toggles
- [ ] Verify keyboard shortcut for sidebar toggle works if configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)