### PR TITLE
Clean up dead legacy CSS, badge code, and unused variables

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -3357,9 +3357,6 @@ function refreshNotesSidebar() {
         <p class="sidebar-empty-hint">Add sticky notes to pages to see them here.</p>
       </div>`;
     replaceIcons();
-    // Update badge
-    const badge = document.querySelector('.sidebar-tab[data-sidebar="notes"] .sidebar-tab-label');
-    if (badge) badge.dataset.count = '';
     return;
   }
 
@@ -3395,10 +3392,6 @@ function refreshNotesSidebar() {
   });
 
   panel.appendChild(list);
-
-  // Update badge count
-  const badge = document.querySelector('.sidebar-tab[data-sidebar="notes"] .sidebar-tab-label');
-  if (badge) badge.dataset.count = notes.length;
 }
 
 /* ═══════════════════ Modal Focus Trapping ═══════════════════ */

--- a/styles/layout.css
+++ b/styles/layout.css
@@ -3030,23 +3030,4 @@ html[data-theme="light"] .crop-shade {
   }
 }
 
-/* ═══════════════════════════════════════
-   LEGACY COMPATIBILITY
-   Ribbon, sidebar, and old layout selectors
-   kept for JS modules that reference them
-   ═══════════════════════════════════════ */
-
-#ribbon-tabs,
-#ribbon-panel,
-#sidebar {
-  display: none;
-}
-
-.ribbon-content,
-.ribbon-tab,
-.ribbon-group,
-.ribbon-btn,
-.sidebar-tab,
-.sidebar-panel {
-  display: none;
-}
+/* Legacy ribbon/sidebar elements removed from HTML in UI overhaul */

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -121,10 +121,6 @@
   --mb-toolbar-hover: var(--mb-bg-elevated);
   --mb-toolbar-active: var(--mb-bg-hover);
   --mb-toolbar-divider: var(--mb-border);
-  --mb-sidebar-bg: var(--mb-bg-secondary);
-  --mb-sidebar-thumb-bg: var(--mb-bg-elevated);
-  --mb-sidebar-thumb-border: var(--mb-border);
-  --mb-sidebar-thumb-active: var(--mb-accent);
   --mb-statusbar-bg: var(--mb-bg-primary);
   --mb-statusbar-text: var(--mb-text-subtle);
   --mb-surface-sunken: var(--mb-bg-secondary);
@@ -137,8 +133,6 @@
   --mb-accent-light: var(--mb-accent-subtle);
   --mb-toolbar-height: var(--mb-titlebar-height);
   --mb-panel-width: 220px;
-  --mb-pagenav-height: 0px;
-  --mb-sidebar-width: 0px;
   --mb-danger: var(--mb-danger);
 }
 


### PR DESCRIPTION
## Summary

- **Removed dead sidebar badge selectors**: Notes panel was querying `.sidebar-tab[data-sidebar="notes"]` which doesn't exist in the new UI
- **Removed legacy CSS rules**: `#ribbon-tabs`, `#ribbon-panel`, `#sidebar`, `.ribbon-*`, `.sidebar-tab`, `.sidebar-panel` — all hidden elements that no longer exist in HTML
- **Removed unused CSS variables**: `--mb-sidebar-bg`, `--mb-sidebar-thumb-*`, `--mb-sidebar-width`, `--mb-pagenav-height`

## Test plan

- [ ] `npm test` — all 621 tests pass
- [ ] Open a PDF, verify no visual regressions
- [ ] Verify notes panel still works (add a sticky note, check it appears in panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)